### PR TITLE
Revert "Bump tracing-bunyan-formatter from 0.3.8 to 0.3.9"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4065,9 +4065,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-bunyan-formatter"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c266b9ac83dedf0e0385ad78514949e6d89491269e7065bee51d2bb8ec7373"
+checksum = "464ce79ea7f689ca56d90a9c5563e803a4b61b2695e789205644ed8e8101e6bf"
 dependencies = [
  "ahash 0.8.3",
  "gethostname",


### PR DESCRIPTION
Reverts MilanLoveless/diner_backend#26